### PR TITLE
timetable 追加

### DIFF
--- a/src/components/index.module.css
+++ b/src/components/index.module.css
@@ -5,10 +5,8 @@
   --w: 280px;
   --n: 2;
   gap: var(--size-gap);
-  grid-template-columns: repeat(
-    auto-fit,
-    minmax(max(var(--w), 100%/ (var(--n) + 1) + 0.1%), 1fr)
-  );
+  grid-template-columns: repeat(auto-fit,
+    minmax(max(var(--w), 100%/ (var(--n) + 1) + 0.1%), 1fr));
   margin-bottom: var(--size-gap);
   margin-top: var(--size-gap);
 }
@@ -84,7 +82,7 @@
 .primaryButtonLarge:hover {
   background-color: #fff;
   border-color: #59b1eb;
-  background-color: var(--color-text);
+  background-color: #001858;
 }
 
 .tweet {
@@ -92,21 +90,66 @@
   justify-content: center;
 }
 
-@media screen and (max-width: 720px){
+.timeTable {
+  text-align: left;
+  border-collapse: collapse;
+  border-spacing: 0;
+  padding: 0 80px;
+  margin: 0 auto;
+  width: calc(100% - 160px);
+}
+
+.timeTable tr {
+  border-top: solid 1px var(--color-text);
+}
+
+.timeTable th {
+  padding: 10px;
+  background-color: var(--color-text);
+  color: #fff;
+}
+
+.timeTable td {
+  padding: 10px;
+  vertical-align: top;
+}
+
+.tableDesc {
+  text-align: left;
+  font-size: 0.875rem;
+  width: calc(100% - 160px);
+  margin-top: 24px;
+}
+
+@media screen and (max-width: 720px) {
   .intro {
     font-size: 1.2rem;
     margin-bottom: 1.2rem;
   }
+
   .intro li {
     margin-bottom: 1.2rem;
   }
+
   .primaryButtonLarge {
     width: 100%;
     height: 60px;
     line-height: 60px;
   }
+
   .specialDesc {
     text-align: left;
     margin-top: 1rem;
+  }
+
+  .timeTable {
+    padding: 0;
+    width: 100%;
+    font-size: 0.875rem;
+  }
+
+  .tableDesc {
+    width: 100%;
+    margin-top: 24px;
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -53,82 +53,93 @@ const IndexPage = () => (
       </ul>
     </div>
     <div className={styles.textCenter}>
-      <h2>
-      Timetable
-      </h2>
-      <div className={styles.textCenter}>
-        <table className={styles.timeTable}>
-         <tr>
-          <th>Time</th>
-          <th>Description</th>
-          </tr>
-         <tr>
-          <td>12:55</td>
-          <td>開場</td>
-         </tr>
-         <tr>
-          <td>13:00-13:10</td>
-          <td>オープニング</td>
-         </tr>
-         <tr>
-          <td>13:10-13:20</td>
-          <td>スポンサーセッション1<br />
-            株式会社クラッソーネ</td>
-         </tr>
-         <tr>
-          <td>13:20-13:50</td>
-          <td>キーノート<br />
-            タイトル<br />
-            大倉 雅史</td>
-         </tr>
-         <tr>
-          <td>13:50-14:20</td>
-          <td>Lightning Talks<br />
-            	『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br />
-              『Rubyコミュニティに参加したら世界が広がった話』 小口 遥さん<br />
-              『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br />
-              『Rubyコミュニティに参加したら世界が広がった話』 小口 遥さん<br />
-              『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br /></td>
-         </tr>
-         <tr>
-          <td>13:50-14:20</td>
-          <td>休憩</td>
-         </tr>
-         <tr>
-          <td>13:50-14:20</td>
-          <td>休憩</td>
-         </tr>
-         <tr>
-          <td>13:50-14:20</td>
-          <td>Lightning Talks<br />
-             『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br />
-              『Rubyコミュニティに参加したら世界が広がった話』 小口 遥さん<br />
-              『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br />
-              『Rubyコミュニティに参加したら世界が広がった話』 小口 遥さん<br />
-              『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br /></td>
-         </tr>
-        </table>
-        <p className={styles.tableDesc}>
-        ※ スケジュールは変更になる可能性があります。<br />
-        ※ 本編終了後には懇親会も予定していますので、ご都合のつく方はぜひご参加ください。詳細は決まり次第ご案内いたします。<br />
-        </p>
-      </div>
+    <h2>
+    Timetable
+    </h2>
+    <div className={styles.textCenter}>
+      <table className={styles.timeTable}>
+       <tr>
+        <th>Time</th>
+        <th>Description</th>
+        </tr>
+       <tr>
+        <td>12:55</td>
+        <td>開場</td>
+       </tr>
+       <tr>
+        <td>13:00-13:10</td>
+        <td>オープニング</td>
+       </tr>
+       <tr>
+        <td>13:10-13:15</td>
+        <td>スポンサーセッション<br />
+          <Link to="https://www.st.inc/" target="_blank">STORES株式会社</Link></td>
+       </tr>
+       <tr>
+        <td>13:15-13:45</td>
+        <td>キーノート1<br /></td>
+       </tr>
+       <tr>
+        <td>13:45-13:55</td>
+        <td>休憩<br /></td>
+       </tr>
+       <tr>
+        <td>13:55-14:30</td>
+        <td>Lightning Talks<br /></td>
+       </tr>
+       <tr>
+        <td>14:30-14:45</td>
+        <td>休憩</td>
+       </tr>
+       <tr>
+        <td>14:45-14:50</td>
+         <td>スポンサーセッション<br />
+           <Link to="https://pepabo.com/" target="_blank">GMOペパボ株式会社</Link></td>
+       </tr>
+       <tr>
+        <td>14:50-15:20</td>
+        <td>キーノート2<br /></td>
+       </tr>
+       <tr>
+        <td>15:20-15:30</td>
+        <td>クロージング</td>
+       </tr>
+      </table>
+      <p className={styles.tableDesc}>
+      ※ スケジュールは変更になる可能性があります。<br />
+      ※ 本編終了後には懇親会も予定していますので、ご都合のつく方はぜひご参加ください。詳細は決まり次第ご案内いたします。<br />
+      </p>
     </div>
     <div className={styles.textCenter}>
       <h2>
       Special
       </h2>
       <p className={styles.specialDesc}>
-        2022年は日本で最初のRails Girlsイベントが開催されて10周年！<br />
-        10周年を記念してメッセージを募集しています。<br />
-        Rails Girlsの思い出・意気込み（野望）・期待など、
-        <b>#rgjp10th</b>をつけてツイートしてくださいね！<br />
+      2022年は日本で最初のRails Girlsイベントが開催されて10周年！<br />
+      10周年を記念してメッセージを募集しています。<br />
+      Rails Girlsの思い出・意気込み（野望）・期待など、
+      <b>#rgjp10th</b>をつけてツイートしてくださいね！<br />
       </p>
+
       <Link to="https://twitter.com/intent/tweet?hashtags=rgjp10th" target="_blank" className={styles.primaryButtonLarge}
       data-show-count="false">
       ツイートする</Link> <br />
-      <Link to="/10th" className={styles.primaryButtonLarge} data-show-count="false">
-      特設ページを見る</Link>
+
+      <Link to="/10th" className={styles.primaryButtonLarge}
+            data-show-count="false">
+        特設ページを見る</Link>
+    </div>
+    <div className={styles.textCenter}>
+      <h2>
+      Shop
+      </h2>
+      <p className={styles.specialDesc}>
+      SUZURIでRails Girls Gathering Japan 2022と10周年記念のグッズを販売中!
+      <br />
+      </p>
+      <Link to="https://suzuri.jp/railsgirls-jp" target="_blank" className={styles.primaryButtonLarge}
+      data-show-count="false">
+      グッズを見る</Link> <br />
     </div>
     <div className={styles.textCenter}>
       <h2>
@@ -146,9 +157,9 @@ const IndexPage = () => (
         <li className={styles.intro}><Link to="https://railsgirls.jp/about" target="blank">Rails Girls Japan</Link></li>
       </ul>
     </div>
-  </Layout>
+  </div>
+</Layout>
 )
-
 /**
  * Head export to define metadata for the page
  *

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -56,7 +56,6 @@ const IndexPage = () => (
     <h2>
     Timetable
     </h2>
-    <div className={styles.textCenter}>
       <table className={styles.timeTable}>
        <tr>
         <th>Time</th>
@@ -155,8 +154,7 @@ const IndexPage = () => (
         <li className={styles.intro}><Link to="https://railsgirls.jp/about" target="blank">Rails Girls Japan</Link></li>
       </ul>
     </div>
-  </div>
-</Layout>
+  </Layout>
 )
 /**
  * Head export to define metadata for the page

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -34,7 +34,7 @@ const IndexPage = () => (
           Online</b>{" "}
         </p>
       <a href="https://railsgirls.jp/code-of-conduct" target="_blank">Code of Conduct</a>
-    </div>
+      </div>
     <div className={styles.news}>
       <p className={styles.textCenter}>
       <b>イベント参加申し込みを開始しました！</b>
@@ -44,54 +44,109 @@ const IndexPage = () => (
     </div>
     </div>
     <div className={styles.textCenter}>
-  <h2>
-  Keynote
-  </h2>
-  <ul className={styles.intro}>
-  <ul className={styles.intro}>
-    <li className={styles.intro}><Link to="https://twitter.com/okuramasafumi" target="blank">大倉 雅史</Link></li>
-    <li className={styles.intro}><Link to="https://twitter.com/yotii23" target="blank">鳥井 雪</Link></li>
-  </ul>
-  </ul>
-</div>
-<div className={styles.textCenter}>
-  <h2>
-  Special
-  </h2>
-  <p className={styles.intro}>
-  </p>
-  <p className={styles.specialDesc}>
-  2022年は日本で最初のRails Girlsイベントが開催されて10周年！<br />
-  10周年を記念してメッセージを募集しています。<br />
-  Rails Girlsの思い出・意気込み（野望）・期待など、
-  <b>#rgjp10th</b>をつけてツイートしてくださいね！<br />
-  </p>
-
-  <Link to="https://twitter.com/intent/tweet?hashtags=rgjp10th" target="_blank" className={styles.primaryButtonLarge}
-  data-show-count="false">
-  ツイートする</Link> <br />
-
-  <Link to="/10th" className={styles.primaryButtonLarge}
-        data-show-count="false">
-    特設ページを見る</Link>
-</div>
-<div className={styles.textCenter}>
-  <h2>
-  Team
-  </h2>
-  <ul className={styles.intro}>
-    <li className={styles.intro}><Link to="https://twitter.com/emorima" target="blank">emorima</Link></li>
-    <li className={styles.intro}><Link to="https://twitter.com/co_bachie" target="blank">cobachie</Link></li>
-    <li className={styles.intro}><Link to="https://twitter.com/yadaita" target="blank">yadaita</Link></li>
-    <li className={styles.intro}><Link to="https://twitter.com/siroemk" target="blank">siroemk</Link></li>
-    <li className={styles.intro}><Link to="https://twitter.com/thatblue_plus" target="blank">thatblue</Link></li>
-    <li className={styles.intro}><Link to="https://twitter.com/ai_24_ai" target="blank">ai-24</Link></li>
-    <li className={styles.intro}><Link to="https://twitter.com/Saki_ht3150" target="blank">Saki</Link></li>
-    <li className={styles.intro}><Link to="https://twitter.com/atttsumi" target="blank">attsumi</Link></li>
-    <li className={styles.intro}><Link to="https://railsgirls.jp/about" target="blank">Rails Girls Japan</Link></li>
-  </ul>
-</div>
-</Layout>
+      <h2>
+      Keynote
+      </h2>
+      <ul className={styles.intro}>
+        <li className={styles.intro}><Link to="https://twitter.com/okuramasafumi" target="blank">大倉 雅史</Link></li>
+        <li className={styles.intro}><Link to="https://twitter.com/yotii23" target="blank">鳥井 雪</Link></li>
+      </ul>
+    </div>
+    <div className={styles.textCenter}>
+      <h2>
+      Timetable
+      </h2>
+      <div className={styles.textCenter}>
+        <table className={styles.timeTable}>
+         <tr>
+          <th>Time</th>
+          <th>Description</th>
+          </tr>
+         <tr>
+          <td>12:55</td>
+          <td>開場</td>
+         </tr>
+         <tr>
+          <td>13:00-13:10</td>
+          <td>オープニング</td>
+         </tr>
+         <tr>
+          <td>13:10-13:20</td>
+          <td>スポンサーセッション1<br />
+            株式会社クラッソーネ</td>
+         </tr>
+         <tr>
+          <td>13:20-13:50</td>
+          <td>キーノート<br />
+            タイトル<br />
+            大倉 雅史</td>
+         </tr>
+         <tr>
+          <td>13:50-14:20</td>
+          <td>Lightning Talks<br />
+            	『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br />
+              『Rubyコミュニティに参加したら世界が広がった話』 小口 遥さん<br />
+              『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br />
+              『Rubyコミュニティに参加したら世界が広がった話』 小口 遥さん<br />
+              『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br /></td>
+         </tr>
+         <tr>
+          <td>13:50-14:20</td>
+          <td>休憩</td>
+         </tr>
+         <tr>
+          <td>13:50-14:20</td>
+          <td>休憩</td>
+         </tr>
+         <tr>
+          <td>13:50-14:20</td>
+          <td>Lightning Talks<br />
+             『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br />
+              『Rubyコミュニティに参加したら世界が広がった話』 小口 遥さん<br />
+              『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br />
+              『Rubyコミュニティに参加したら世界が広がった話』 小口 遥さん<br />
+              『エンジニアになるきっかけ、Rails Girls!!』 浅海 舞さん<br /></td>
+         </tr>
+        </table>
+        <p className={styles.tableDesc}>
+        ※ スケジュールは変更になる可能性があります。<br />
+        ※ 本編終了後には懇親会も予定していますので、ご都合のつく方はぜひご参加ください。詳細は決まり次第ご案内いたします。<br />
+        </p>
+      </div>
+    </div>
+    <div className={styles.textCenter}>
+      <h2>
+      Special
+      </h2>
+      <p className={styles.specialDesc}>
+        2022年は日本で最初のRails Girlsイベントが開催されて10周年！<br />
+        10周年を記念してメッセージを募集しています。<br />
+        Rails Girlsの思い出・意気込み（野望）・期待など、
+        <b>#rgjp10th</b>をつけてツイートしてくださいね！<br />
+      </p>
+      <Link to="https://twitter.com/intent/tweet?hashtags=rgjp10th" target="_blank" className={styles.primaryButtonLarge}
+      data-show-count="false">
+      ツイートする</Link> <br />
+      <Link to="/10th" className={styles.primaryButtonLarge} data-show-count="false">
+      特設ページを見る</Link>
+    </div>
+    <div className={styles.textCenter}>
+      <h2>
+      Team
+      </h2>
+      <ul className={styles.intro}>
+        <li className={styles.intro}><Link to="https://twitter.com/emorima" target="blank">emorima</Link></li>
+        <li className={styles.intro}><Link to="https://twitter.com/co_bachie" target="blank">cobachie</Link></li>
+        <li className={styles.intro}><Link to="https://twitter.com/yadaita" target="blank">yadaita</Link></li>
+        <li className={styles.intro}><Link to="https://twitter.com/siroemk" target="blank">siroemk</Link></li>
+        <li className={styles.intro}><Link to="https://twitter.com/thatblue_plus" target="blank">thatblue</Link></li>
+        <li className={styles.intro}><Link to="https://twitter.com/ai_24_ai" target="blank">ai-24</Link></li>
+        <li className={styles.intro}><Link to="https://twitter.com/Saki_ht3150" target="blank">Saki</Link></li>
+        <li className={styles.intro}><Link to="https://twitter.com/atttsumi" target="blank">attsumi</Link></li>
+        <li className={styles.intro}><Link to="https://railsgirls.jp/about" target="blank">Rails Girls Japan</Link></li>
+      </ul>
+    </div>
+  </Layout>
 )
 
 /**


### PR DESCRIPTION
```
13:00-13:10	オープニング
13:10-13:15	スポンサーLT1: STORES @fujimura さん
13:15-10:45	キーノート1	@okuramasafumi さん
13:45-13:55	休憩	
13:55〜14:30 LT
  LT1: @maimu さん
  LT2: @haruna tsujita さん
  LT3: @murokaco さん
  LT4: @emorima さん
  LT5: @thatblue さん
  LT6: @hsbt さん
14:30-14:45	休憩	
14:45-14:50	スポンサーLT2:  GMOペパボ @kyokutyo さん
14:50-15:20	キーノート2:	@Yuki さん
15:20-15:30	クロージング
```

https://railsgirlsjp.slack.com/archives/C049B2GEW2F/p1668928312387939
↑の情報をもとに
- スポンサー企業様は社名含めて出す
- キーノートはバイネームは記載しない（とりいさんが上の Slack をまだ確認してなさそうだったので）
- LTは一旦枠

<img width="601" alt="スクリーンショット 0004-11-23 22 59 44" src="https://user-images.githubusercontent.com/6082554/203565551-af93654c-d242-4e00-b55b-0414810fb29c.png">
